### PR TITLE
Add lint fix script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:fix": "next lint --fix",
     "test": "vitest --run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a `lint:fix` npm script in frontend/package.json to automatically fix lint errors

## Testing
- `npm test`
- `npm run lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_684afbc363c083238248e97c0499e991