### PR TITLE
Set up vitest for React client

### DIFF
--- a/OnParDev.Mcp.Api/ClientApp/package.json
+++ b/OnParDev.Mcp.Api/ClientApp/package.json
@@ -8,7 +8,9 @@
     "start": "npm run prestart && vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview --https"
+    "preview": "vite preview --https",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -16,6 +18,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
@@ -23,8 +27,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "jsdom": "^26.1.0",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.2.3"
   }
 }
-

--- a/OnParDev.Mcp.Api/ClientApp/src/App.test.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/App.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import App from './App'
+
+describe('App', () => {
+  it('renders the header', () => {
+    render(<App />)
+    expect(screen.getByRole('heading', { name: /vite \+ react/i })).toBeInTheDocument()
+  })
+})

--- a/OnParDev.Mcp.Api/ClientApp/src/setupTests.ts
+++ b/OnParDev.Mcp.Api/ClientApp/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/OnParDev.Mcp.Api/ClientApp/tsconfig.json
+++ b/OnParDev.Mcp.Api/ClientApp/tsconfig.json
@@ -15,6 +15,9 @@
         "isolatedModules": true,
         "noEmit": true,
         "jsx": "react-jsx",
+        "types": [
+            "vitest/globals"
+        ],
         /* Linting */
         "strict": true,
         "noUnusedLocals": true,

--- a/OnParDev.Mcp.Api/ClientApp/vite.config.js
+++ b/OnParDev.Mcp.Api/ClientApp/vite.config.js
@@ -7,6 +7,11 @@ import process from "process";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+  },
   server: {
     https: getHttpsSettings(),
     port: 5173,


### PR DESCRIPTION
## Summary
- add vitest and testing libraries
- configure vitest in Vite
- enable vitest globals in tsconfig
- add sample App test and setup file

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c86ebce108323bf8c8f876f45aa7f