### PR TITLE
Adjust Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/OnParDev.Mcp.Api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/OnParDev.Mcp.Api/ClientApp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- run Dependabot weekly on Mondays for both NuGet and npm

## Testing
- `dotnet build OnParDev.Mcp.sln -v q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c8f19c2fc8323b2c6a27b51a21a5a