### PR TITLE
Add empty xUnit test project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/OnParDev.Mcp.Api.Tests/GlobalUsings.cs
+++ b/OnParDev.Mcp.Api.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/OnParDev.Mcp.Api.Tests/OnParDev.Mcp.Api.Tests.csproj
+++ b/OnParDev.Mcp.Api.Tests/OnParDev.Mcp.Api.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OnParDev.Mcp.Api\OnParDev.Mcp.Api.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/OnParDev.Mcp.Api/OnParDev.Mcp.Api.csproj
+++ b/OnParDev.Mcp.Api/OnParDev.Mcp.Api.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OnParDev.Mcp.sln
+++ b/OnParDev.Mcp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnParDev.Mcp.Api", "OnParDev.Mcp.Api\OnParDev.Mcp.Api.csproj", "{F7126378-92E0-42DE-9FAD-795A3EDB4BF0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnParDev.Mcp.Api.Tests", "OnParDev.Mcp.Api.Tests\OnParDev.Mcp.Api.Tests.csproj", "{C3446D53-46C1-4BC6-A4CD-988621ADA690}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{F7126378-92E0-42DE-9FAD-795A3EDB4BF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7126378-92E0-42DE-9FAD-795A3EDB4BF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7126378-92E0-42DE-9FAD-795A3EDB4BF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3446D53-46C1-4BC6-A4CD-988621ADA690}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3446D53-46C1-4BC6-A4CD-988621ADA690}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3446D53-46C1-4BC6-A4CD-988621ADA690}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3446D53-46C1-4BC6-A4CD-988621ADA690}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- scaffold OnParDev.Mcp.Api.Tests using xUnit and .NET 8
- reference API project from the new test project
- include the tests project in the solution
- switch to NuGet Central Package Management

## Testing
- `dotnet test OnParDev.Mcp.sln -v minimal`
- `npm run lint` in `OnParDev.Mcp.Api/ClientApp`
- `npm test` in `OnParDev.Mcp.Api/ClientApp` *(fails: Unable to find heading element)*

------
https://chatgpt.com/codex/tasks/task_e_684c91005a508323924b46514ee3d0ab