### PR TITLE
Add config endpoint with React context

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,5 +10,6 @@
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
   </ItemGroup>
 </Project>

--- a/OnParDev.Mcp.Api.Tests/Integration/ApiFactory.cs
+++ b/OnParDev.Mcp.Api.Tests/Integration/ApiFactory.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace OnParDev.Mcp.Api.Tests.Integration;
+
+public class ApiFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Production");
+    }
+}

--- a/OnParDev.Mcp.Api.Tests/Integration/ConfigEndpointsTests.cs
+++ b/OnParDev.Mcp.Api.Tests/Integration/ConfigEndpointsTests.cs
@@ -1,0 +1,22 @@
+using System.Net.Http.Json;
+
+using OnParDev.Mcp.Api.Config;
+
+namespace OnParDev.Mcp.Api.Tests.Integration;
+
+public class ConfigEndpointsTests : IClassFixture<ApiFactory>
+{
+    private readonly HttpClient _client;
+    public ConfigEndpointsTests(ApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ReturnsGoogleClientId()
+    {
+        var response = await _client.GetFromJsonAsync<ConfigResponse>("/api/config");
+        Assert.NotNull(response);
+        Assert.Equal(string.Empty, response!.GoogleClientId);
+    }
+}

--- a/OnParDev.Mcp.Api.Tests/OnParDev.Mcp.Api.Tests.csproj
+++ b/OnParDev.Mcp.Api.Tests/OnParDev.Mcp.Api.Tests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OnParDev.Mcp.Api/ClientApp/src/App.test.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/App.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import App from './App'
+import { ConfigProvider } from './config/ConfigContext'
 
 describe('App', () => {
   it('renders the header', () => {
-    render(<App />)
+    render(
+      <ConfigProvider initialConfig={{ googleClientId: 'id' }}>
+        <App />
+      </ConfigProvider>
+    )
     expect(screen.getByRole('heading', { name: /MyMCP/i })).toBeInTheDocument()
   })
 })

--- a/OnParDev.Mcp.Api/ClientApp/src/App.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/App.tsx
@@ -1,6 +1,8 @@
 import './App.css'
+import { useConfig } from './config/ConfigContext'
 
 function App() {
+  useConfig()
   return (
     <>
       <h1>MyMCP</h1>

--- a/OnParDev.Mcp.Api/ClientApp/src/config/ConfigContext.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/config/ConfigContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, FC, ReactNode, useContext, useEffect, useState } from 'react'
+
+export interface Config {
+  googleClientId: string
+}
+
+const ConfigContext = createContext<Config | undefined>(undefined)
+
+export const ConfigProvider: FC<{ children: ReactNode; initialConfig?: Config }> = ({ children, initialConfig }) => {
+  const [config, setConfig] = useState<Config | undefined>(initialConfig)
+
+  useEffect(() => {
+    if (!initialConfig) {
+      fetch('/api/config')
+        .then((r) => r.json())
+        .then(setConfig)
+    }
+  }, [initialConfig])
+
+  if (!config) return null
+
+  return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+}
+
+export const useConfig = () => {
+  const ctx = useContext(ConfigContext)
+  if (!ctx) throw new Error('Config not loaded')
+  return ctx
+}

--- a/OnParDev.Mcp.Api/ClientApp/src/main.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ConfigProvider } from './config/ConfigContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ConfigProvider>
+      <App />
+    </ConfigProvider>
   </StrictMode>,
 )

--- a/OnParDev.Mcp.Api/Config/ConfigResponse.cs
+++ b/OnParDev.Mcp.Api/Config/ConfigResponse.cs
@@ -1,0 +1,3 @@
+namespace OnParDev.Mcp.Api.Config;
+
+public record ConfigResponse(string GoogleClientId);

--- a/OnParDev.Mcp.Api/Config/Endpoints.cs
+++ b/OnParDev.Mcp.Api/Config/Endpoints.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+
+namespace OnParDev.Mcp.Api.Config;
+
+public static class Endpoints
+{
+    public static IEndpointRouteBuilder MapConfigEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/config", (IOptions<GoogleSsoSettings> google) =>
+            Results.Ok(new ConfigResponse(google.Value.ClientId)));
+        return endpoints;
+    }
+}

--- a/OnParDev.Mcp.Api/Config/GoogleSsoSettings.cs
+++ b/OnParDev.Mcp.Api/Config/GoogleSsoSettings.cs
@@ -1,0 +1,7 @@
+namespace OnParDev.Mcp.Api.Config;
+
+public class GoogleSsoSettings
+{
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+}

--- a/OnParDev.Mcp.Api/Config/Services.cs
+++ b/OnParDev.Mcp.Api/Config/Services.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OnParDev.Mcp.Api.Config;
+
+public static class Services
+{
+    public static IServiceCollection AddConfigServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<GoogleSsoSettings>(configuration.GetSection("GoogleSSO"));
+        return services;
+    }
+}

--- a/OnParDev.Mcp.Api/Program.cs
+++ b/OnParDev.Mcp.Api/Program.cs
@@ -1,3 +1,4 @@
+using OnParDev.Mcp.Api.Config;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -8,6 +9,7 @@ builder.Services.AddSpaStaticFiles(configuration =>
 {
     configuration.RootPath = "ClientApp/dist";
 });
+builder.Services.AddConfigServices(builder.Configuration);
 
 var app = builder.Build();
 
@@ -29,6 +31,7 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
 
+app.MapConfigEndpoints();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}");
@@ -36,3 +39,5 @@ app.MapControllerRoute(
 app.MapFallbackToFile("index.html");
 
 app.Run();
+
+public partial class Program { }

--- a/OnParDev.Mcp.Api/appsettings.Development.json
+++ b/OnParDev.Mcp.Api/appsettings.Development.json
@@ -6,5 +6,9 @@
       "Microsoft.AspNetCore.SpaProxy": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "GoogleSSO": {
+    "ClientId": "",
+    "ClientSecret": ""
   }
 }

--- a/OnParDev.Mcp.Api/appsettings.json
+++ b/OnParDev.Mcp.Api/appsettings.json
@@ -6,5 +6,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "GoogleSSO": {
+    "ClientId": "",
+    "ClientSecret": ""
+  }
 }


### PR DESCRIPTION
## Summary
- expose `/api/config` with minimal API
- wrap frontend in `ConfigProvider` to load configuration
- load Google SSO settings from `appsettings.json`
- move ApiFactory to its own file and place integration tests in `Integration`
- verify config endpoint returns the configured value
- fix whitespace lint issues

## Testing
- `npm run lint`
- `npm test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_684cea7287588323b3a88d95b16dcd94