### PR TITLE
Add simple pages and router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/bin/
+**/obj/
+OnParDev.Mcp.Api/ClientApp/dist/

--- a/OnParDev.Mcp.Api/ClientApp/src/App.test.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/App.test.tsx
@@ -1,14 +1,21 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import App from './App'
 import { ConfigProvider } from './config/ConfigContext'
+import { AuthProvider } from './auth/AuthContext'
+
+const renderApp = () =>
+  render(
+    <ConfigProvider initialConfig={{ googleClientId: 'id' }}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ConfigProvider>,
+  )
 
 describe('App', () => {
-  it('renders the header', () => {
-    render(
-      <ConfigProvider initialConfig={{ googleClientId: 'id' }}>
-        <App />
-      </ConfigProvider>
-    )
-    expect(screen.getByRole('heading', { name: /MyMCP/i })).toBeInTheDocument()
+  it('navigates to pricing page', () => {
+    renderApp()
+    fireEvent.click(screen.getByRole('button', { name: /pricing/i }))
+    expect(screen.getByRole('heading', { name: /pricing/i })).toBeInTheDocument()
   })
 })

--- a/OnParDev.Mcp.Api/ClientApp/src/App.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/App.tsx
@@ -1,12 +1,62 @@
+import { useEffect, useState } from 'react'
 import './App.css'
 import { useConfig } from './config/ConfigContext'
+import Landing from './pages/Landing'
+import SignIn from './pages/SignIn'
+import SignUp from './pages/SignUp'
+import Pricing from './pages/Pricing'
+import Contact from './pages/Contact'
+import { useAuth } from './auth/AuthContext'
 
 function App() {
   useConfig()
+  const { isAuthenticated, logout } = useAuth()
+  const [path, setPath] = useState(window.location.pathname)
+
+  useEffect(() => {
+    const onPop = () => setPath(window.location.pathname)
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+
+  const navigate = (newPath: string) => {
+    window.history.pushState({}, '', newPath)
+    setPath(newPath)
+  }
+
+  let content
+  switch (path) {
+    case '/signup':
+      content = <SignUp />
+      break
+    case '/signin':
+      content = <SignIn />
+      break
+    case '/pricing':
+      content = <Pricing />
+      break
+    case '/contact':
+      content = <Contact />
+      break
+    default:
+      content = <Landing />
+  }
+
   return (
     <>
-      <h1>MyMCP</h1>
-      <p className="tagline">Model Context Protocol server as a service</p>
+      <nav>
+        <button onClick={() => navigate('/')}>Home</button>
+        {!isAuthenticated && (
+          <>
+            <button onClick={() => navigate('/signup')}>Sign Up</button>
+            <button onClick={() => navigate('/signin')}>Sign In</button>
+          </>
+        )}
+        <button onClick={() => navigate('/pricing')}>Pricing</button>
+        <button onClick={() => navigate('/contact')}>Contact</button>
+        {isAuthenticated && <button onClick={logout}>Logout</button>}
+      </nav>
+      {content}
     </>
   )
 }

--- a/OnParDev.Mcp.Api/ClientApp/src/auth/AuthContext.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/auth/AuthContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, FC, ReactNode, useContext, useState } from 'react'
+
+interface AuthContextValue {
+  isAuthenticated: boolean
+  login: () => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [isAuthenticated, setAuthenticated] = useState(false)
+
+  const login = () => setAuthenticated(true)
+  const logout = () => setAuthenticated(false)
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('Auth not loaded')
+  return ctx
+}

--- a/OnParDev.Mcp.Api/ClientApp/src/main.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { ConfigProvider } from './config/ConfigContext'
+import { AuthProvider } from './auth/AuthContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ConfigProvider>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </ConfigProvider>
   </StrictMode>,
 )

--- a/OnParDev.Mcp.Api/ClientApp/src/pages/Contact.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/pages/Contact.tsx
@@ -1,0 +1,10 @@
+function Contact() {
+  return (
+    <>
+      <h1>Contact Us</h1>
+      <p>Email us at contact@example.com.</p>
+    </>
+  )
+}
+
+export default Contact

--- a/OnParDev.Mcp.Api/ClientApp/src/pages/Landing.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/pages/Landing.tsx
@@ -1,0 +1,10 @@
+function Landing() {
+  return (
+    <>
+      <h1>MyMCP</h1>
+      <p className="tagline">Model Context Protocol server as a service</p>
+    </>
+  )
+}
+
+export default Landing

--- a/OnParDev.Mcp.Api/ClientApp/src/pages/Pricing.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/pages/Pricing.tsx
@@ -1,0 +1,10 @@
+function Pricing() {
+  return (
+    <>
+      <h1>Pricing</h1>
+      <p>Choose the plan that fits your needs.</p>
+    </>
+  )
+}
+
+export default Pricing

--- a/OnParDev.Mcp.Api/ClientApp/src/pages/SignIn.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/pages/SignIn.tsx
@@ -1,0 +1,13 @@
+import { useAuth } from '../auth/AuthContext'
+
+function SignIn() {
+  const { login } = useAuth()
+  return (
+    <>
+      <h1>Sign In</h1>
+      <button onClick={login}>Log In</button>
+    </>
+  )
+}
+
+export default SignIn

--- a/OnParDev.Mcp.Api/ClientApp/src/pages/SignUp.tsx
+++ b/OnParDev.Mcp.Api/ClientApp/src/pages/SignUp.tsx
@@ -1,0 +1,13 @@
+import { useAuth } from '../auth/AuthContext'
+
+function SignUp() {
+  const { login } = useAuth()
+  return (
+    <>
+      <h1>Sign Up</h1>
+      <button onClick={login}>Create Account</button>
+    </>
+  )
+}
+
+export default SignUp


### PR DESCRIPTION
## Summary
- create AuthContext for sign-in/out
- implement basic client-side router
- add landing, sign in, sign up, pricing and contact pages
- update tests for navigation

## Testing
- `npm run lint`
- `npm test`
- `dotnet test OnParDev.Mcp.sln`


------
https://chatgpt.com/codex/tasks/task_e_684f4d0f8b888323869d113ff00d5e8d