### PR TITLE
Add builtin servers dashboard

### DIFF
--- a/app/app/servers/page.tsx
+++ b/app/app/servers/page.tsx
@@ -1,0 +1,32 @@
+import { Server } from 'lucide-react'
+import Link from 'next/link'
+import { BuiltInServerTable } from '@/components/BuiltInServerTable'
+
+export default function ServersPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <nav className="bg-white/80 backdrop-blur-md border-b border-slate-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2">
+              <Server className="h-8 w-8 text-blue-600" />
+              <span className="text-xl font-bold text-slate-900">MCPaaS</span>
+            </Link>
+            <div className="flex items-center space-x-8">
+              <Link href="/" className="text-slate-600 hover:text-slate-900 transition-colors">
+                Home
+              </Link>
+              <Link href="/dashboard" className="text-slate-600 hover:text-slate-900 transition-colors">
+                Dashboard
+              </Link>
+            </div>
+          </div>
+        </div>
+      </nav>
+      <main className="max-w-4xl mx-auto p-8">
+        <h1 className="text-2xl font-bold mb-6">Built-in MCP Servers</h1>
+        <BuiltInServerTable />
+      </main>
+    </div>
+  )
+}

--- a/app/components/BuiltInServerTable.tsx
+++ b/app/components/BuiltInServerTable.tsx
@@ -1,0 +1,29 @@
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { builtinServers } from '@/lib/servers'
+
+export function BuiltInServerTable() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {builtinServers.map((server) => (
+          <TableRow key={server.id}>
+            <TableCell className="font-medium">{server.name}</TableCell>
+            <TableCell className="capitalize">{server.type}</TableCell>
+            <TableCell>
+              <span className={server.status === 'running' ? 'text-green-600' : 'text-red-600'}>
+                {server.status}
+              </span>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/app/lib/servers.ts
+++ b/app/lib/servers.ts
@@ -1,0 +1,15 @@
+export interface BuiltinServer {
+  id: string;
+  name: string;
+  type: string;
+  status: 'running' | 'stopped';
+}
+
+export const builtinServers: BuiltinServer[] = [
+  {
+    id: 'github',
+    name: 'GitHub MCP Server',
+    type: 'github',
+    status: 'running',
+  },
+];


### PR DESCRIPTION
## Summary
- list builtin servers
- create reusable BuiltInServerTable component
- add `/servers` page to display built-in MCP servers

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850b467a1108323ae2ada4ad2cd3054