### PR TITLE
Add subscription info with Stripe API

### DIFF
--- a/app/app/api/subscription/route.ts
+++ b/app/app/api/subscription/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? '', {
+  apiVersion: '2023-10-16'
+});
+
+export async function GET() {
+  const customerId = process.env.STRIPE_CUSTOMER_ID;
+  if (!customerId) {
+    return NextResponse.json({ error: 'Missing customer id' }, { status: 400 });
+  }
+
+  try {
+    const subs = await stripe.subscriptions.list({ customer: customerId, limit: 1 });
+    const sub = subs.data[0];
+    const plan = sub?.items.data[0].price.nickname ?? 'Unknown';
+    const usage = sub?.items.data[0].quantity ?? 0;
+    return NextResponse.json({ plan, usage });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch subscription' }, { status: 500 });
+  }
+}

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Server, Github, Play, Square, Settings, Plus, Activity, Users, Database, Zap } from 'lucide-react'
 import Link from 'next/link'
 
 export default function DashboardPage() {
+  const [subscription, setSubscription] = useState<{ plan: string; usage: number } | null>(null)
   const [servers, setServers] = useState([
     {
       id: 1,
@@ -27,12 +28,26 @@ export default function DashboardPage() {
   ])
 
   const toggleServer = (id: number) => {
-    setServers(servers.map(server => 
-      server.id === id 
+    setServers(servers.map(server =>
+      server.id === id
         ? { ...server, status: server.status === 'running' ? 'stopped' : 'running' }
         : server
     ))
   }
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/subscription')
+        if (res.ok) {
+          setSubscription(await res.json())
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    load()
+  }, [])
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -113,6 +128,14 @@ export default function DashboardPage() {
             </div>
           </div>
         </div>
+
+        {subscription && (
+          <div className="bg-white rounded-xl p-6 border border-slate-200 mb-8">
+            <h3 className="text-xl font-semibold text-slate-900 mb-2">Subscription</h3>
+            <p className="text-slate-600">Plan: {subscription.plan}</p>
+            <p className="text-slate-600">MCP Usage: {subscription.usage}</p>
+          </div>
+        )}
 
         {/* Servers Section */}
         <div className="bg-white rounded-xl border border-slate-200 mb-8">

--- a/app/lib/usage.ts
+++ b/app/lib/usage.ts
@@ -1,0 +1,5 @@
+export function formatUsage(usage: number, limit: number): string {
+  if (limit <= 0) return '0%';
+  const ratio = Math.min(1, usage / limit);
+  return `${Math.round(ratio * 100)}%`;
+}

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -61,11 +62,16 @@
     "react-resizable-panels": "^2.1.3",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
+    "stripe": "^18.2.1",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.2.2",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.3",
+    "vitest": "^3.2.3"
   }
 }

--- a/app/test/usage.test.ts
+++ b/app/test/usage.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { formatUsage } from '../lib/usage';
+
+describe('formatUsage', () => {
+  it('calculates percentage', () => {
+    expect(formatUsage(25, 50)).toBe('50%');
+  });
+
+  it('caps at 100%', () => {
+    expect(formatUsage(120, 100)).toBe('100%');
+  });
+});


### PR DESCRIPTION
## Summary
- integrate Stripe SDK
- expose `/api/subscription` endpoint
- show active plan and usage on dashboard
- add `formatUsage` helper with tests
- run tests with vitest using `expect`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850b48375a483239fdbaa0ffc4e8fe3