### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/app/e2e/home.spec.ts
+++ b/app/e2e/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('home page has title', async ({ page }) => {
+  await page.goto('http://localhost:3000')
+  await expect(page).toHaveTitle(/mcp/i)
+})

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -72,6 +73,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.0",
     "tsx": "^4.20.3",
     "vitest": "^3.2.3"
   }

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,7 @@
+import { PlaywrightTestConfig } from '@playwright/test'
+
+const config: PlaywrightTestConfig = {
+  testDir: './e2e'
+}
+
+export default config

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.ts'],
+    exclude: ['e2e/**']
+  }
+})


### PR DESCRIPTION
## Summary
- add Playwright with an example spec
- add Playwright config
- exclude e2e directory from Vitest

## Testing
- `npm run lint`
- `npm test`
- `npx playwright test` *(fails: browser download required)*

------
https://chatgpt.com/codex/tasks/task_e_6850cc66d768832385bcc7f02852386c