### PR TITLE
Fix build without Google fonts

### DIFF
--- a/app/app/api/subscription/route.ts
+++ b/app/app/api/subscription/route.ts
@@ -1,17 +1,20 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? '', {
-  apiVersion: '2025-05-28.basil'
-});
-
 export async function GET() {
+  const apiKey = process.env.STRIPE_SECRET_KEY;
   const customerId = process.env.STRIPE_CUSTOMER_ID;
   if (!customerId) {
     return NextResponse.json({ error: 'Missing customer id' }, { status: 400 });
   }
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing API key' }, { status: 500 });
+  }
 
   try {
+    const stripe = new Stripe(apiKey, { apiVersion: '2025-05-28.basil' });
     const subs = await stripe.subscriptions.list({ customer: customerId, limit: 1 });
     const sub = subs.data[0];
     const plan = sub?.items.data[0].price.nickname ?? 'Unknown';

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,9 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import AuthProvider from '@/components/session-provider';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -17,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body>
         <AuthProvider>{children}</AuthProvider>
       </body>
     </html>

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- remove external font to avoid network fetch
- make Stripe API handler safer
- allow Next.js to build dynamic API routes

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685151f343288323b9fcf8634508b55d