### PR TITLE
Move unit tests beside source files

### DIFF
--- a/app/lib/subscription.test.ts
+++ b/app/lib/subscription.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from 'vitest'
-import { getSubscription } from '../lib/subscription'
+import { getSubscription } from './subscription'
 
 describe('getSubscription', () => {
   it('returns plan and usage', async () => {

--- a/app/lib/usage.test.ts
+++ b/app/lib/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatUsage } from '../lib/usage';
+import { formatUsage } from './usage';
 
 describe('formatUsage', () => {
   it('calculates percentage', () => {

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['test/**/*.ts'],
-    exclude: ['e2e/**']
+    include: ['**/*.test.ts'],
+    exclude: ['e2e/**', 'node_modules/**']
   }
 })


### PR DESCRIPTION
## Summary
- relocate usage & subscription tests next to code
- adjust imports after move
- broaden vitest config to find tests anywhere while excluding node_modules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851561409708323a8facc22956ca857