### PR TITLE
Add Docker build and web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ Fun project for spinning up MCP servers as a service.
 
 Run `docker compose up` to start Postgres and apply migrations.
 
+## Building and running
+
+Build the web container and start all services:
+
+```bash
+docker compose build
+docker compose up
+```
+
+Visit <http://localhost:3000> once the containers are running.
+

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+coverage
+playwright-report
+.next

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,11 @@ services:
       FLYWAY_PASSWORD: dev
     depends_on:
       - db
+
+  web:
+    build: ./app
+    env_file: .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
## Summary
- create Dockerfile to build Next.js app
- ignore build artifacts in Docker context
- set up `web` service in docker-compose
- document building and running the containers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68530e71f420832391014c970ff85b45