### PR TITLE
Add user sign-out and session display

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -3,8 +3,8 @@ name: PR Verify
 on:
   pull_request:
     paths-ignore:
-      - '**/*.md'
-      - 'flyway/**'
+      - "**/*.md"
+      - "flyway/**"
 
 jobs:
   verify:
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
           cache-dependency-path: app/package-lock.json
       - name: Install dependencies
         run: npm ci
@@ -42,14 +42,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
           cache-dependency-path: app/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Build
+        env:
+          NEXT_PUBLIC_TEST_SESSION: true
+          NEXTAUTH_SECRET: test-secret-for-ci
         run: npm run build
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
       - name: Run e2e tests
+        env:
+          NEXT_PUBLIC_TEST_SESSION: true
+          NEXTAUTH_SECRET: test-secret-for-ci
         run: npx concurrently -k -s first "npm run start" "npx wait-on http://localhost:3000 && npm run test:e2e"
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log*
 pnpm-debug.log*
 
 # Local env files
+.env
 .env.local
 .env.development.local
 .env.test.local
@@ -27,6 +28,9 @@ pnpm-debug.log*
 
 # Coverage directory
 coverage/
+
+# Test results
+test-results/
 
 # Next.js cache
 .next/cache/

--- a/app/app/about/page.tsx
+++ b/app/app/about/page.tsx
@@ -1,5 +1,6 @@
 import { Server, Users, Zap, Shield, Github, Linkedin, Twitter } from 'lucide-react'
 import Link from 'next/link'
+import { UserMenu } from '@/components/UserMenu'
 
 export default function AboutPage() {
   return (
@@ -22,9 +23,7 @@ export default function AboutPage() {
               <Link href="/docs" className="text-slate-600 hover:text-slate-900 transition-colors">
                 Docs
               </Link>
-              <Link href="/login" className="text-slate-600 hover:text-slate-900 transition-colors">
-                Sign In
-              </Link>
+              <UserMenu />
               <Link href="/dashboard" className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">
                 Dashboard
               </Link>

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Server, Github, Play, Square, Settings, Plus, Activity, Users, Database, Zap } from 'lucide-react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
 import { SubscriptionInfo } from '@/components/SubscriptionInfo'
+import { UserMenu } from '@/components/UserMenu'
 
 export default function DashboardPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
   const [servers, setServers] = useState([
     {
       id: 1,
@@ -28,13 +33,24 @@ export default function DashboardPage() {
   ])
 
   const toggleServer = (id: number) => {
-    setServers(servers.map(server =>
-      server.id === id
-        ? { ...server, status: server.status === 'running' ? 'stopped' : 'running' }
-        : server
-    ))
+    setServers(
+      servers.map((server) =>
+        server.id === id
+          ? { ...server, status: server.status === 'running' ? 'stopped' : 'running' }
+          : server
+      )
+    )
   }
 
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.replace('/login')
+    }
+  }, [status, router])
+
+  if (status !== 'authenticated') {
+    return null
+  }
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -50,9 +66,7 @@ export default function DashboardPage() {
               <button className="text-slate-600 hover:text-slate-900 transition-colors">
                 <Settings className="h-5 w-5" />
               </button>
-              <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
-                <span className="text-white text-sm font-medium">U</span>
-              </div>
+              <UserMenu />
             </div>
           </div>
         </div>

--- a/app/app/docs/page.tsx
+++ b/app/app/docs/page.tsx
@@ -10,6 +10,7 @@ import {
   Check,
 } from "lucide-react";
 import Link from "next/link";
+import { UserMenu } from "@/components/UserMenu";
 import { useState } from "react";
 
 function CodeBlock({
@@ -72,12 +73,7 @@ export default function DocsPage() {
               >
                 About
               </Link>
-              <Link
-                href="/login"
-                className="text-slate-600 hover:text-slate-900 transition-colors"
-              >
-                Sign In
-              </Link>
+              <UserMenu />
               <Link
                 href="/dashboard"
                 className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"

--- a/app/app/login/page.tsx
+++ b/app/app/login/page.tsx
@@ -1,31 +1,36 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { Github, Mail, Server, Eye, EyeOff } from 'lucide-react'
-import Link from 'next/link'
-import { signIn } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { useState } from "react";
+import { Server, Eye, EyeOff } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OAuthButton } from "@/components/OAuthButton";
 
 export default function LoginPage() {
-  const [showPassword, setShowPassword] = useState(false)
-  const [isLogin, setIsLogin] = useState(true)
-  const router = useRouter()
-  const testMode = process.env.NEXT_PUBLIC_TEST_SESSION === 'true'
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLogin, setIsLogin] = useState(true);
+  const router = useRouter();
+  const testMode = process.env.NEXT_PUBLIC_TEST_SESSION === "true";
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex items-center justify-center p-4">
       <div className="max-w-md w-full">
         {/* Header */}
         <div className="text-center mb-8">
-          <Link href="/" className="flex items-center justify-center space-x-2 mb-6">
+          <Link
+            href="/"
+            className="flex items-center justify-center space-x-2 mb-6"
+          >
             <Server className="h-10 w-10 text-blue-600" />
             <span className="text-2xl font-bold text-slate-900">MyMCP</span>
           </Link>
           <h1 className="text-3xl font-bold text-slate-900 mb-2">
-            {isLogin ? 'Welcome back' : 'Create your account'}
+            {isLogin ? "Welcome back" : "Create your account"}
           </h1>
           <p className="text-slate-600">
-            {isLogin ? 'Sign in to your account' : 'Start building with MCP servers today'}
+            {isLogin
+              ? "Sign in to your account"
+              : "Start building with MCP servers today"}
           </p>
         </div>
 
@@ -33,27 +38,8 @@ export default function LoginPage() {
         <div className="bg-white rounded-2xl shadow-xl p-8 border border-slate-200">
           {/* Social Login */}
           <div className="space-y-3 mb-6">
-            <button
-              onClick={async () => {
-                if (testMode) {
-                  await signIn('test', { redirect: false })
-                  router.push('/')
-                } else {
-                  await signIn('github')
-                }
-              }}
-              className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors"
-            >
-              <Github className="h-5 w-5 text-slate-700" />
-              <span className="font-medium text-slate-700">Continue with GitHub</span>
-            </button>
-            <button
-              onClick={() => signIn(testMode ? 'test' : 'google')}
-              className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors"
-            >
-              <Mail className="h-5 w-5 text-slate-700" />
-              <span className="font-medium text-slate-700">Continue with Google</span>
-            </button>
+            <OAuthButton provider="github" testMode={testMode} />
+            <OAuthButton provider="google" testMode={testMode} />
           </div>
 
           {/* Divider */}
@@ -62,7 +48,9 @@ export default function LoginPage() {
               <div className="w-full border-t border-slate-300"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-white text-slate-500">Or continue with email</span>
+              <span className="px-2 bg-white text-slate-500">
+                Or continue with email
+              </span>
             </div>
           </div>
 
@@ -70,7 +58,10 @@ export default function LoginPage() {
           <form className="space-y-4">
             {!isLogin && (
               <div>
-                <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-2">
+                <label
+                  htmlFor="name"
+                  className="block text-sm font-medium text-slate-700 mb-2"
+                >
                   Full Name
                 </label>
                 <input
@@ -81,9 +72,12 @@ export default function LoginPage() {
                 />
               </div>
             )}
-            
+
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-2">
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-slate-700 mb-2"
+              >
                 Email Address
               </label>
               <input
@@ -93,15 +87,18 @@ export default function LoginPage() {
                 placeholder="Enter your email"
               />
             </div>
-            
+
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-slate-700 mb-2">
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-slate-700 mb-2"
+              >
                 Password
               </label>
               <div className="relative">
                 <input
                   id="password"
-                  type={showPassword ? 'text' : 'password'}
+                  type={showPassword ? "text" : "password"}
                   className="w-full px-3 py-3 pr-10 border border-slate-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   placeholder="Enter your password"
                 />
@@ -127,11 +124,17 @@ export default function LoginPage() {
                     type="checkbox"
                     className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-slate-300 rounded"
                   />
-                  <label htmlFor="remember" className="ml-2 block text-sm text-slate-700">
+                  <label
+                    htmlFor="remember"
+                    className="ml-2 block text-sm text-slate-700"
+                  >
                     Remember me
                   </label>
                 </div>
-                <Link href="/forgot-password" className="text-sm text-blue-600 hover:text-blue-500">
+                <Link
+                  href="/forgot-password"
+                  className="text-sm text-blue-600 hover:text-blue-500"
+                >
                   Forgot password?
                 </Link>
               </div>
@@ -141,7 +144,7 @@ export default function LoginPage() {
               type="submit"
               className="w-full bg-blue-600 text-white py-3 px-4 rounded-xl font-medium hover:bg-blue-700 transition-colors"
             >
-              {isLogin ? 'Sign In' : 'Create Account'}
+              {isLogin ? "Sign In" : "Create Account"}
             </button>
           </form>
 
@@ -153,7 +156,7 @@ export default function LoginPage() {
                 onClick={() => setIsLogin(!isLogin)}
                 className="text-blue-600 hover:text-blue-500 font-medium ml-1"
               >
-                {isLogin ? 'Sign up' : 'Sign in'}
+                {isLogin ? "Sign up" : "Sign in"}
               </button>
             </p>
           </div>
@@ -161,16 +164,17 @@ export default function LoginPage() {
 
         {/* Footer */}
         <div className="mt-8 text-center text-sm text-slate-500">
-          By continuing, you agree to our{' '}
+          By continuing, you agree to our{" "}
           <Link href="/terms" className="text-blue-600 hover:text-blue-500">
             Terms of Service
-          </Link>{' '}
-          and{' '}
+          </Link>{" "}
+          and{" "}
           <Link href="/privacy" className="text-blue-600 hover:text-blue-500">
             Privacy Policy
           </Link>
         </div>
       </div>
     </div>
-  )
+  );
 }
+

--- a/app/app/login/page.tsx
+++ b/app/app/login/page.tsx
@@ -4,10 +4,13 @@ import { useState } from 'react'
 import { Github, Mail, Server, Eye, EyeOff } from 'lucide-react'
 import Link from 'next/link'
 import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [isLogin, setIsLogin] = useState(true)
+  const router = useRouter()
+  const testMode = process.env.NEXT_PUBLIC_TEST_SESSION === 'true'
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex items-center justify-center p-4">
@@ -31,14 +34,21 @@ export default function LoginPage() {
           {/* Social Login */}
           <div className="space-y-3 mb-6">
             <button
-              onClick={() => signIn('github')}
+              onClick={async () => {
+                if (testMode) {
+                  await signIn('test', { redirect: false })
+                  router.push('/')
+                } else {
+                  await signIn('github')
+                }
+              }}
               className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors"
             >
               <Github className="h-5 w-5 text-slate-700" />
               <span className="font-medium text-slate-700">Continue with GitHub</span>
             </button>
             <button
-              onClick={() => signIn('google')}
+              onClick={() => signIn(testMode ? 'test' : 'google')}
               className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors"
             >
               <Mail className="h-5 w-5 text-slate-700" />

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,5 +1,6 @@
 import { Github, Server, Zap, Shield, Code, ArrowRight, Check } from 'lucide-react'
 import Link from 'next/link'
+import { UserMenu } from '@/components/UserMenu'
 
 export default function HomePage() {
   return (
@@ -22,9 +23,7 @@ export default function HomePage() {
               <Link href="/about" className="text-slate-600 hover:text-slate-900 transition-colors">
                 About
               </Link>
-              <Link href="/login" className="text-slate-600 hover:text-slate-900 transition-colors">
-                Sign In
-              </Link>
+              <UserMenu />
               <Link href="/dashboard" className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">
                 Dashboard
               </Link>

--- a/app/app/pricing/page.tsx
+++ b/app/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 import { Check, X, Zap, Shield, Headphones } from 'lucide-react'
 import Link from 'next/link'
+import { UserMenu } from '@/components/UserMenu'
 
 export default function PricingPage() {
   return (
@@ -21,9 +22,7 @@ export default function PricingPage() {
               <Link href="/docs" className="text-slate-600 hover:text-slate-900 transition-colors">
                 Docs
               </Link>
-              <Link href="/login" className="text-slate-600 hover:text-slate-900 transition-colors">
-                Sign In
-              </Link>
+              <UserMenu />
               <Link href="/dashboard" className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">
                 Dashboard
               </Link>

--- a/app/app/servers/page.tsx
+++ b/app/app/servers/page.tsx
@@ -1,8 +1,16 @@
 import { Server } from 'lucide-react'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getServerSession } from 'next-auth/next'
 import { BuiltInServerTable } from '@/components/BuiltInServerTable'
+import { UserMenu } from '@/components/UserMenu'
+import { authOptions } from '@/lib/auth'
 
-export default function ServersPage() {
+export default async function ServersPage() {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    redirect('/login')
+  }
   return (
     <div className="min-h-screen bg-slate-50">
       <nav className="bg-white/80 backdrop-blur-md border-b border-slate-200">
@@ -19,6 +27,7 @@ export default function ServersPage() {
               <Link href="/dashboard" className="text-slate-600 hover:text-slate-900 transition-colors">
                 Dashboard
               </Link>
+              <UserMenu />
             </div>
           </div>
         </div>

--- a/app/components/OAuthButton.tsx
+++ b/app/components/OAuthButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Github, Mail } from "lucide-react";
+import { signIn } from "next-auth/react";
+
+type OAuthProvider = "github" | "google";
+
+interface OAuthButtonProps {
+  provider: OAuthProvider;
+  testMode?: boolean;
+  className?: string;
+}
+
+const providerConfig = {
+  github: {
+    icon: Github,
+    label: "GitHub",
+    providerId: "github",
+  },
+  google: {
+    icon: Mail,
+    label: "Google",
+    providerId: "google",
+  },
+};
+
+export function OAuthButton({
+  provider,
+  testMode = false,
+  className = "",
+}: OAuthButtonProps) {
+  const config = providerConfig[provider];
+  const Icon = config.icon;
+
+  const handleClick = async () => {
+    if (testMode) {
+      await signIn("test", { callbackUrl: "/" });
+    } else {
+      await signIn(config.providerId);
+    }
+  };
+
+  const buttonText = `Continue with ${config.label}`;
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`w-full flex items-center justify-center gap-3 px-4 py-3 border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors ${className}`}
+    >
+      <Icon className="h-5 w-5 text-slate-700" />
+      <span className="font-medium text-slate-700">{buttonText}</span>
+    </button>
+  );
+}
+

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -1,0 +1,41 @@
+'use client'
+import Link from 'next/link'
+import { signOut, useSession } from 'next-auth/react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+
+export function UserMenu() {
+  const { data: session } = useSession()
+  if (!session) {
+    return (
+      <Link
+        href="/login"
+        className="text-slate-600 hover:text-slate-900 transition-colors"
+      >
+        Sign In
+      </Link>
+    )
+  }
+  const user = session.user
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Avatar className="w-8 h-8" data-testid="user-menu-trigger">
+          {user?.image && (
+            <AvatarImage src={user.image} alt={user.name ?? 'User'} />
+          )}
+          <AvatarFallback>{user?.name ? user.name.charAt(0) : 'U'}</AvatarFallback>
+        </Avatar>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <div className="px-2 py-1 text-sm">{user?.name}</div>
+        <DropdownMenuItem onSelect={() => signOut()}>Sign Out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/e2e/auth.spec.ts
+++ b/app/e2e/auth.spec.ts
@@ -1,15 +1,23 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from "@playwright/test";
 
-const login = async (page) => {
-  await page.goto('/login')
-  await page.getByRole('button', { name: 'Continue with GitHub' }).click()
-  await page.waitForURL('/')
-}
+const login = async (page: Page) => {
+  await page.goto("/login");
+  await page.getByRole("button", { name: "Continue with GitHub" }).click();
+  await page.waitForURL("/");
+};
 
-test('can sign in and sign out', async ({ page }) => {
-  await login(page)
-  await page.getByTestId('user-menu-trigger').click()
-  await page.getByRole('menuitem', { name: 'Sign Out' }).click()
-  await expect(page).toHaveURL('/')
-  await expect(page.getByText('Sign In')).toBeVisible()
-})
+test("can sign in and sign out", async ({ page }) => {
+  await login(page);
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("menuitem", { name: "Sign Out" }).click();
+  await expect(page).toHaveURL("/");
+  await expect(page.getByText("Sign In")).toBeVisible();
+});
+
+test("can sign in with Google button", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("/");
+  await expect(page.getByTestId("user-menu-trigger")).toBeVisible();
+});
+

--- a/app/e2e/auth.spec.ts
+++ b/app/e2e/auth.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+
+const login = async (page) => {
+  await page.goto('/login')
+  await page.getByRole('button', { name: 'Continue with GitHub' }).click()
+  await page.waitForURL('/')
+}
+
+test('can sign in and sign out', async ({ page }) => {
+  await login(page)
+  await page.getByTestId('user-menu-trigger').click()
+  await page.getByRole('menuitem', { name: 'Sign Out' }).click()
+  await expect(page).toHaveURL('/')
+  await expect(page.getByText('Sign In')).toBeVisible()
+})

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,17 +1,31 @@
 import type { NextAuthOptions } from 'next-auth'
 import GitHubProvider from 'next-auth/providers/github'
 import GoogleProvider from 'next-auth/providers/google'
+import CredentialsProvider from 'next-auth/providers/credentials'
+
+const testMode = process.env.NEXT_PUBLIC_TEST_SESSION === 'true'
 
 export const authOptions: NextAuthOptions = {
-  providers: [
-    GitHubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID ?? '',
-      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
-    }),
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
-    }),
-  ],
+  providers: testMode
+    ? [
+        CredentialsProvider({
+          id: 'test',
+          name: 'Test',
+          credentials: {},
+          async authorize() {
+            return { id: '1', name: 'Test User', email: 'test@example.com' }
+          },
+        }),
+      ]
+    : [
+        GitHubProvider({
+          clientId: process.env.GITHUB_CLIENT_ID ?? '',
+          clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
+        }),
+        GoogleProvider({
+          clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+        }),
+      ],
   secret: process.env.NEXTAUTH_SECRET,
 }

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright install && playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -80,3 +80,4 @@
     "vitest": "^3.2.3"
   }
 }
+

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,7 +1,14 @@
 import { PlaywrightTestConfig } from '@playwright/test'
 
 const config: PlaywrightTestConfig = {
-  testDir: './e2e'
+  testDir: './e2e',
+  use: { baseURL: 'http://localhost:3000' },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    env: { NEXT_PUBLIC_TEST_SESSION: 'true' },
+    reuseExistingServer: true,
+  },
 }
 
 export default config

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,14 +1,18 @@
-import { PlaywrightTestConfig } from '@playwright/test'
+import { PlaywrightTestConfig } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
-  testDir: './e2e',
-  use: { baseURL: 'http://localhost:3000' },
+  testDir: "./e2e",
+  use: { baseURL: "http://localhost:3000" },
   webServer: {
-    command: 'npm run dev',
+    command: "npm run dev",
     port: 3000,
-    env: { NEXT_PUBLIC_TEST_SESSION: 'true' },
+    env: {
+      NEXT_PUBLIC_TEST_SESSION: "true",
+      NEXTAUTH_SECRET: "test-secret-for-playwright",
+    },
     reuseExistingServer: true,
   },
-}
+};
 
-export default config
+export default config;
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   db:
     image: postgres:16-alpine
@@ -27,3 +26,4 @@ services:
       - "3000:3000"
     depends_on:
       - db
+


### PR DESCRIPTION
## Summary
- show user name and sign-out option through new `UserMenu`
- display `UserMenu` in all navigation bars
- require authentication for Dashboard and Servers pages
- add test-only auth provider and e2e login/logout test

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6853146d22ec83238fc4ea6ef9afefa9