### PR TITLE
chore: upgrade GitHub Actions to v4 and enhance Playwright caching

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -13,8 +13,8 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -39,21 +39,44 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
           cache-dependency-path: app/package-lock.json
+
+      # Cache Playwright browsers
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm list @playwright/test --depth=0 --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install dependencies
         run: npm ci
+
       - name: Build
         env:
           NEXT_PUBLIC_TEST_SESSION: true
           NEXTAUTH_SECRET: test-secret-for-ci
         run: npm run build
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
       - name: Run e2e tests
         env:
           NEXT_PUBLIC_TEST_SESSION: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/pr-verify.yml` file to improve CI workflows by upgrading dependencies and optimizing Playwright browser caching and installation. The changes enhance efficiency and ensure compatibility with newer versions of GitHub Actions and Playwright.

### Dependency Updates:
* Updated `actions/checkout` and `actions/setup-node` to version `v4` for improved compatibility and features. (`[[1]](diffhunk://#diff-3824cab4ca2a7114a280480d6502299fd5f39409a112d44b6d6be5000648a35eL16-R17)`, `[[2]](diffhunk://#diff-3824cab4ca2a7114a280480d6502299fd5f39409a112d44b6d6be5000648a35eL42-R79)`)

### Playwright Integration Enhancements:
* Added steps to cache Playwright browsers using `actions/cache@v4`, reducing redundant downloads and improving workflow speed. (`[.github/workflows/pr-verify.ymlL42-R79](diffhunk://#diff-3824cab4ca2a7114a280480d6502299fd5f39409a112d44b6d6be5000648a35eL42-R79)`)
* Introduced conditional installation of Playwright browsers and system dependencies based on cache hits to optimize installation processes. (`[.github/workflows/pr-verify.ymlL42-R79](diffhunk://#diff-3824cab4ca2a7114a280480d6502299fd5f39409a112d44b6d6be5000648a35eL42-R79)`)